### PR TITLE
Handle loading mocks for the test harness

### DIFF
--- a/bin/tapped
+++ b/bin/tapped
@@ -15,6 +15,9 @@ try {
     // Initialise the testing environment.
     environment(getcwd() . DIRECTORY_SEPARATOR . 'tests');
 
+    // Define the mocks for our testing
+    environment()->loadMocks();
+
     // Load in the default comparisons which ship with the Framework.
     comparisons()->registerMany(
         require_once __DIR__ . '/../configuration/comparisons.php'

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -48,6 +48,24 @@ class Environment
     }
 
     /**
+     * Loads the mocks for the test harness.
+     */
+    public function loadMocks()
+    {
+        if (is_file($this->mocksFile())) {
+            require_once $this->mocksFile();
+        }
+    }
+
+    /**
+     * Returns the file which should contain the mocks.
+     */
+    public function mocksFile(): string
+    {
+        return $this->path . DIRECTORY_SEPARATOR . 'mocks.php';
+    }
+
+    /**
      * Returns the files which are deemed to contain tests.
      */
     public function testFiles(): array


### PR DESCRIPTION
This PR introduces the ability for the framework to load mocks in a test harness.

Following this change, users can create a file called `tests/mocks.php` which will be loaded at the framework startup.

The format of this file is up to the user.